### PR TITLE
Source sh-compatible rtisetenv script before building.

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -21,41 +21,53 @@ export DEB_CXXFLAGS_MAINT_APPEND=-DNDEBUG
 %:
 	dh $@@ -v --buildsystem=cmake
 
-override_dh_auto_configure:
+override_dh_auto_configure: /tmp/rtienv.sh
 	# In case we're installing to a non-standard location, look for a setup.sh
 	# in the install tree and source it.  It will set things like
 	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
+	. /tmp/rtienv.sh && \
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_configure -- \
 		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
 		-DAMENT_PREFIX_PATH="@(InstallationPrefix)" \
 		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)"
 
-override_dh_auto_build:
+override_dh_auto_build: /tmp/rtienv.sh
 	# In case we're installing to a non-standard location, look for a setup.sh
 	# in the install tree and source it.  It will set things like
 	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
+	. /tmp/rtienv.sh && \
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_build
 
-override_dh_auto_test:
+override_dh_auto_test: /tmp/rtienv.sh
 	# In case we're installing to a non-standard location, look for a setup.sh
 	# in the install tree and source it.  It will set things like
 	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
+	. /tmp/rtienv.sh && \
 	echo -- Running tests. Even if one of them fails the build is not canceled.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_test || true
 
-override_dh_shlibdeps:
+override_dh_shlibdeps: /tmp/rtienv.sh
 	# In case we're installing to a non-standard location, look for a setup.sh
 	# in the install tree and source it.  It will set things like
 	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
+	. /tmp/rtienv.sh && \
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_shlibdeps -l$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/lib/
 
-override_dh_auto_install:
+override_dh_auto_install: /tmp/rtienv.sh
 	# In case we're installing to a non-standard location, look for a setup.sh
 	# in the install tree and source it.  It will set things like
 	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
+	. /tmp/rtienv.sh && \
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_install
+
+/tmp/rtienv.sh:
+	if [ -f /opt/rti.com/rti_connext_dds-5.3.1/resource/scripts/rtisetenv_x64Linux3gcc5.4.0.bash ]; then \
+	sed -e 's:\$${BASH_SOURCE\[0\]}:/opt/rti.com/rti_connext_dds-5.3.1/resource/scripts/rtisetenv_x64Linux3gcc5.4.0.bash:' \
+	/opt/rti.com/rti_connext_dds-5.3.1/resource/scripts/rtisetenv_x64Linux3gcc5.4.0.bash \
+	> /tmp/rtienv.sh; \
+	else touch /tmp/rtienv.sh; fi


### PR DESCRIPTION
In order for this package to properly detect the installed Connext DDS
installation the setup script must be sourced before build actions.
Since the build runs in a sh-compatible setting the bash-specific
functionality of the script must be patched out.