### PR TITLE
Replace environment script with exported environment variable.

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -23,6 +23,9 @@ endif
 
 DEB_HOST_GNU_TYPE ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
 
+# Set CONNEXTDDS_DIR variable so this package can find its rti-connext-dds dependency.
+export CONNEXTDDS_DIR=/opt/rti.com/rti_connext_dds-6.0.1
+
 %:
 	dh $@@ -v --buildsystem=cmake --builddirectory=.obj-$(DEB_HOST_GNU_TYPE)
 


### PR DESCRIPTION
The rti_connext_dds_cmake_module is capable of finding Connext using the CONNEXTDDS_DIR environment variable which is the preferred method of finding Connext.

This also decreases the patch surface which will hopefully make it more robust going forward.

This was taken from 365a892ece3a8d1aa31252a2f199a5aade64586c