### PR TITLE
Update Lyrical to use Connext 7.7.0.

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -24,7 +24,7 @@ endif
 DEB_HOST_GNU_TYPE ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
 
 # Set CONNEXTDDS_DIR variable so this package can find its rti-connext-dds dependency.
-export CONNEXTDDS_DIR=/opt/rti.com/rti_connext_dds-7.3.0
+export CONNEXTDDS_DIR=/opt/rti.com/rti_connext_dds-7.7.0
 
 %:
 	dh $@@ -v --buildsystem=cmake --builddirectory=.obj-$(DEB_HOST_GNU_TYPE)


### PR DESCRIPTION
Otherwise the package build will not find the path, and the resulting package has no librmw_connextdds.so